### PR TITLE
Adding information about tutorial video

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,11 +3,15 @@
 import { navigation } from "@/models/navigation";
 import Link from "next/link";
 import Disclaimer from "./Disclaimer";
+import Tutorial from "./Tutorial";
 
 export default function Footer() {
   return (
     <footer>
       <div className="mx-auto max-w-7xl overflow-hidden px-6 py-20 sm:py-24 lg:px-8">
+        <div className="pb-6">
+          <Tutorial />
+        </div>
         <div className="pb-6">
           <Disclaimer />
         </div>

--- a/src/components/Tutorial.tsx
+++ b/src/components/Tutorial.tsx
@@ -1,0 +1,19 @@
+import { IconInfoCircleFilled } from "@tabler/icons-react";
+
+export default function Tutorial() {
+  return (
+    <div className="rounded-md alert-info-background p-4">
+      <div className="flex">
+        <div className="flex-shrink-0">
+          <IconInfoCircleFilled className="h-5 w-5 alert-info-icon" aria-hidden="true" />
+        </div>
+        <div className="ml-3 flex-1 md:flex md:justify-between">
+          <p className="text-sm alert-info-title">
+            Learn how to use Fenix Calc by checking a <a className="underline" target="_blank" href="https://www.youtube.com/live/YQVkpQyM8os?feature=share&t=1003">video here</a>.
+          </p>
+          <p className="mt-3 text-sm md:ml-6 md:mt-0"></p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
It is worth adding an extra explanation, especially since it is ready from your last eth launch stream.

![image](https://github.com/atomizexyz/fenixcalccom/assets/12344862/aa757d02-d602-4b80-8173-350316f9c311)


You can clip video on yt to shrink it, and then replace it in code.
![image](https://github.com/atomizexyz/fenixcalccom/assets/12344862/c50ef367-39fc-45fc-84d2-9b4d36605e6c)
